### PR TITLE
Fix sourcetable response for V1

### DIFF
--- a/src/transport/server/ntrip.ts
+++ b/src/transport/server/ntrip.ts
@@ -539,13 +539,13 @@ export class NtripTransport extends Transport {
                 this.res.flushHeaders();
             }
 
-            private printSourcetable() {
+            private async printSourcetable(): Promise<void> {
                 this.res.statusVersion = 'SOURCETABLE';
                 this.res.setHeader('Connection', 'close');
                 this.res.setHeader('Server', 'NTRIP ' + Caster.NAME + '/1.0');
                 this.res.setHeader('Content-Type', 'text/plain');
                 this.res.sendDate = true;
-                this.res.end(this.transport.getSourcetable(this.req.query?.query));
+                this.res.end(await this.transport.getSourcetable(this.req.query?.query));
             }
         };
 


### PR DESCRIPTION
This fixes #4 (error requesting sourcetable using V1):

```
(node:25713) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be of type string or an instance of Buffer. Received an instance of Promise
    at NtripCasterResponse.end (_http_outgoing.js:811:13)
    at V1Processor.printSourcetable (/snapshot/nodcas/node_modules/@ntrip/caster/build/transport/server/ntrip.js:503:22)
    at V1Processor.acceptClient (/snapshot/nodcas/node_modules/@ntrip/caster/build/transport/server/ntrip.js:478:29)
    at V1Processor.accept (/snapshot/nodcas/node_modules/@ntrip/caster/build/transport/server/ntrip.js:439:28)
    at HttpRequestProcessor.accept (/snapshot/nodcas/node_modules/@ntrip/caster/build/transport/server/ntrip.js:417:66)
    at NtripTransport.accept (/snapshot/nodcas/node_modules/@ntrip/caster/build/transport/server/ntrip.js:211:75)
    at Server.<anonymous> (/snapshot/nodcas/node_modules/@ntrip/caster/build/transport/server/ntrip.js:122:54)
    at Server.emit (events.js:376:20)
    at parserOnIncoming (_http_server.js:896:12)
    at NtripHTTPParser.parserOnHeadersComplete (_http_common.js:126:17)
(Use `caster --trace-warnings ...` to show where the warning was created)
(node:25713) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a prom
ise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#c
li_unhandled_rejections_mode). (rejection id: 2)
```