### PR TITLE
Add Content-Length header to sourcetable response.

### DIFF
--- a/src/transport/server/ntrip.ts
+++ b/src/transport/server/ntrip.ts
@@ -543,11 +543,13 @@ export class NtripTransport extends Transport {
 
             private async printSourcetable(): Promise<void> {
                 this.res.statusVersion = 'SOURCETABLE';
+                const sourceTable = await this.transport.getSourcetable(this.req.query?.query);
                 this.res.setHeader('Connection', 'close');
                 this.res.setHeader('Server', 'NTRIP ' + Caster.NAME + '/1.0');
                 this.res.setHeader('Content-Type', 'text/plain');
+                this.res.setHeader('Content-Length', Buffer.byteLength(sourceTable));
                 this.res.sendDate = true;
-                this.res.end(await this.transport.getSourcetable(this.req.query?.query));
+                this.res.end(sourceTable);
             }
         };
 


### PR DESCRIPTION
This allows the u-center program by ublox to parse the table response properly.  When no content-length is sent, it is impossible to select a mountpoint in the u-center interface.

This was deduced by looking at the http response from the closed-source SNIP caster at rtk2go.com:2101 using curl. 
e.g. `curl rtk2go.com:2101 -A "NTRIP client" --http0.9`